### PR TITLE
Add priority option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- `priority` configuration
 
 ## [1.1.1]
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ You can also set to `false` to disable caching.
 
 Ideally, the cache file should not be checked in into repository.
 
+#### priority
+
+The priority of the `after_generate` filter. Defaults to 10.
+You can find more information about priority in [Filter](https://hexo.io/api/filter.html) documentation.
+
 #### default_type
 
 Defaults to `potrace`. Use this type if not specified as a param to `lqip_for` helper.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var lqip = require('./lqip')
+var config = lqip.getConfig(hexo)
 
-hexo.extend.filter.register('after_generate', lqip.afterGenerate);
+hexo.extend.filter.register('after_generate', lqip.afterGenerate, config.priority);
 hexo.extend.filter.register('after_clean', lqip.afterClean);
 hexo.extend.helper.register('lqip_for', lqip.lqipFor)

--- a/lqip/index.js
+++ b/lqip/index.js
@@ -57,6 +57,8 @@ function getConfig(hexo) {
   }, theme.lqip)
 }
 
+exports.getConfig = getConfig
+
 exports.afterClean = function () {
   var hexo = this
   var config = getConfig(hexo)


### PR DESCRIPTION
Allow to set a priority of the `after_generate` filter.
It may be useful for controlling interaction with other plugins.