### PR TITLE
chore: specify files to publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-specs
-preview.gif
-.travis.yml

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "scripts": {
     "test": "ava specs/*_spec.js"
   },
+  "directories": {
+    "lqip": "./lqip"
+  },
+  "files": [
+    "index.js",
+    "lqip/"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hexojs/hexo-filter-lqip.git"


### PR DESCRIPTION
```
$ npm publish --dry-run
npm notice 
npm notice 📦  hexo-filter-lqip@1.3.2
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE                
npm notice 959B  lqip/types/color.js    
npm notice 588B  lqip/cache/filecache.js
npm notice 324B  index.js               
npm notice 327B  lqip/cache/index.js    
npm notice 1.9kB lqip/index.js          
npm notice 267B  lqip/stats/index.js    
npm notice 82B   lqip/types/index.js    
npm notice 160B  lqip/cache/nocache.js  
npm notice 904B  lqip/types/potrace.js  
npm notice 2.0kB lqip/process.js        
npm notice 1.4kB lqip/svgo.js           
npm notice 1.4kB lqip/utils.js          
npm notice 1.1kB package.json           
npm notice 771B  CHANGELOG.md           
npm notice 4.2kB README.md
```